### PR TITLE
fix buildNewCluster memory leak

### DIFF
--- a/clustermanager/client/multiclient.go
+++ b/clustermanager/client/multiclient.go
@@ -162,6 +162,8 @@ func (mc *multiClient) buildNewCluster(newClsInfo api.ClusterCfgInfo, options *O
 	// start new client
 	err = start(mc.ctx, cli, mc.BeforStartHandleList)
 	if err != nil {
+		// clear client resources
+		cli.Stop()
 		return nil, err
 	}
 


### PR DESCRIPTION
when start function return an error, the client should be closed